### PR TITLE
Fix wrong documentation link in footer element

### DIFF
--- a/site/views/footer.html
+++ b/site/views/footer.html
@@ -18,7 +18,7 @@
 				<a href="https://www.botcity.dev">BotCity Automation Platform</a>
 			</div>
 			<div class="footer_section_item">
-				<a href="https://developers.botcity.dev/portal">Developers Portal</a>
+				<a href="https://documentation.botcity.dev">Developers Portal</a>
 			</div>
 			<div class="footer_section_item">
 				<a href="https://community.botcity.dev">Forum</a>


### PR DESCRIPTION
Developers Portal link in the footer is pointing to https://developers.botcity.dev/portal and get 404.

Just fixed to point to https://documentation.botcity.dev