### PR TITLE
Add referral links

### DIFF
--- a/build.py
+++ b/build.py
@@ -65,15 +65,28 @@ def generate_for_entry(deploy_path, uid, entry):
     entry["upload_date_iso"] = upload_date_iso
 
     share = f"""
+        <p style="margin-top: 10px">
+            <b>Share this Bot:</b>
+        </p>
         <div class="div_share">
-
-            <b>Share this Bot:</b><br/>
             <!-- AddToAny BEGIN -->
             <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_copy_link"></a>
+            </div>
+
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-linkedin" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_linkedin"></a>
+            </div>
+
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-whatsapp" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_whatsapp"></a>
+            </div>
+
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-twitter" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_twitter"></a>
+            </div>
+
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-email" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_email"></a>
             </div>
             <script async src="https://static.addtoany.com/menu/page.js"></script>

--- a/build.py
+++ b/build.py
@@ -70,7 +70,7 @@ def generate_for_entry(deploy_path, uid, entry):
         </p>
         <div class="div_share">
             <!-- AddToAny BEGIN -->
-            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-copy" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_copy_link"></a>
             </div>
 
@@ -86,6 +86,14 @@ def generate_for_entry(deploy_path, uid, entry):
                 <a class="a2a_button_twitter"></a>
             </div>
 
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-telegram" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
+                <a class="a2a_button_telegram"></a>
+            </div>          
+
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-mastodon" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
+                <a class="a2a_button_mastodon"></a>
+            </div>
+            
             <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-url="https://repository.botcity.dev/bot-{uid}.html?utm_source=bot-repository&utm_medium=referral-email" data-a2a-title="I liked this bot that I saw in the Bot Repository. Check it out.">
                 <a class="a2a_button_email"></a>
             </div>

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -255,7 +255,7 @@ body{
 }
 
 .div_share{
-	margin-top:10px;
+	margin: 10px 0 20px;
 	display: flex;
 	flex-direction: row;
 }

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -256,6 +256,8 @@ body{
 
 .div_share{
 	margin-top:10px;
+	display: flex;
+	flex-direction: row;
 }
 
 /**


### PR DESCRIPTION
We had to adjust the links to share in social media, so we can verify in Google Analytics after the event.

We tested:
- Copy link: 
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/d8c3d1f5-72b5-4fb0-b02e-dd89a15cdf24)

- LinkedIn:
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/fb3156d3-558a-47ec-82e9-0976b9078d37)

- WhatsApp:
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/93fd810a-8e15-45a6-96d3-d5c766aa6bbf)

- Twitter:
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/e1e0bd43-8cee-4d66-8c49-bc08575d8e21)

- Telegram:
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/979c37f3-74a6-4fb3-8a81-5f7dffbae8b6)

- Mastodon:
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/9b1fc624-abe0-44a1-91c0-1fcd338b5ef7)

- E-mail:
![image](https://github.com/botcity-dev/bot-repository/assets/19210643/76c70924-41e8-4919-9c63-6c056ac97cad)

And all the links were checked with Marketing and Growth Team.